### PR TITLE
Added flags for ignoring the users/torrents table when importing

### DIFF
--- a/src/Commands/FromXbtit.php
+++ b/src/Commands/FromXbtit.php
@@ -24,7 +24,9 @@ class FromXbtit extends Command
                             {--database= : The database to select from.}
                             {--username= : The database user.}
                             {--password= : The database password.}
-                            {--prefix= : The database hostname or IP.}';
+                            {--prefix= : The database hostname or IP.}
+                            {--ignore-users : Ignore the users table when importing.}
+                            {--ignore-torrents : Ignore the torrents table when importing.}';
 
     /**
      * The console command description.

--- a/src/Commands/FromXbtit.php
+++ b/src/Commands/FromXbtit.php
@@ -71,8 +71,17 @@ class FromXbtit extends Command
 
         $database = DB::connection('imports');
 
-        Imports::importTable($database, 'User', 'users', User::class);
-        Imports::importTable($database, 'Torrent', 'files', Torrent::class);
+        if (!$this->option('ignore-users')) {
+            Imports::importTable($database, 'User', 'users', User::class);
+        } else {
+            $this->output->note('Ignoring users table.');
+        }
+
+        if (!$this->option('ignore-torrents')) {
+            Imports::importTable($database, 'Torrent', 'files', Torrent::class);
+        } else {
+            $this->output->note('Ignoring torrents table.');
+        }
     }
 
     /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Added 2 new flags for ignoring either the `torrents` or `users` when importing from XBTIT.

## Motivation and context

This allows users to choose which tables they would like to import when running the command, providing more usability and customisation.

Closes #2

## How has this been tested?

I've tested this in a development UNIT3D environment.

## Screenshots (if appropriate)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [ ] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
